### PR TITLE
fix format guessing in Chooser::addFile()

### DIFF
--- a/src/Chooser.php
+++ b/src/Chooser.php
@@ -4,6 +4,7 @@ namespace Distill;
 
 use Distill\Exception\FormatGuesserRequiredException;
 use Distill\Exception\InvalidArgumentException;
+use Distill\Exception\IO\Input\FileUnknownFormatException;
 use Distill\Exception\StrategyRequiredException;
 use Distill\Format\FormatInterface;
 use Distill\Strategy\StrategyInterface;
@@ -126,7 +127,7 @@ class Chooser
      * @param string               $filename File name
      * @param FormatInterface|null $format   Format
      *
-     * @throws Exception\FormatGuesserRequiredException
+     * @throws Exception\FormatGuesserRequiredException|FileUnknownFormatException
      * @return Chooser
      */
     public function addFile($filename, FormatInterface $format = null)
@@ -136,7 +137,13 @@ class Chooser
                 throw new FormatGuesserRequiredException();
             }
 
-            $format = $this->formatGuesser->guess($filename);
+            $formatChain = $this->formatGuesser->guess($filename)->getChainFormats();
+
+            if (count($formatChain) === 0) {
+                throw new FileUnknownFormatException($filename);
+            }
+
+            $format = $formatChain[0];
         }
 
         $this->files[] = new File($filename, $format);


### PR DESCRIPTION
The `guess()` method from the `FormatGuesserInterface` does not return a `FormatInterface`, but returns a `FormatChainInterface` instance instead.

@raulfraile I'm not sure if it's best to throw a `FileUnknownFormatException` here if no format could be guessed. What do you think?
