### PR TITLE
fix handling of format chains in Chooser

### DIFF
--- a/src/Chooser.php
+++ b/src/Chooser.php
@@ -5,6 +5,7 @@ namespace Distill;
 use Distill\Exception\FormatGuesserRequiredException;
 use Distill\Exception\InvalidArgumentException;
 use Distill\Exception\StrategyRequiredException;
+use Distill\Format\FormatChainInterface;
 use Distill\Format\FormatInterface;
 use Distill\Strategy\StrategyInterface;
 use Distill\Method\MethodInterface;
@@ -123,13 +124,13 @@ class Chooser
 
     /**
      * Adds a new file.
-     * @param string               $filename File name
-     * @param FormatInterface|null $formatChain   Format
+     * @param string                    $filename    File name
+     * @param FormatChainInterface|null $formatChain Format
      *
      * @throws Exception\FormatGuesserRequiredException
      * @return Chooser
      */
-    public function addFile($filename, FormatInterface $formatChain = null)
+    public function addFile($filename, FormatChainInterface $formatChain = null)
     {
         if (null === $formatChain) {
             if (null === $this->formatGuesser) {
@@ -245,7 +246,7 @@ class Chooser
 
         if (true === $this->excludeUnsupported) {
             return array_values(array_filter($preferredFiles, function (FileInterface $file) {
-                return $this->supportChecker->isFormatSupported($file->getFormat());
+                return $this->supportChecker->isFormatChainSupported($file->getFormatChain());
             }));
         }
 


### PR DESCRIPTION
There are two issues in the `Chooser` class since b47351b6b59a60519fec0fe714a7008796165b9e which prevent a proper handling of format chains:
- `addFile()` passes a `FormatInterface` instance to the `File` constructor if the `$formatChain` argument is not `null`
- `getPreferredFilesOrdered()` calls an undefined method `getFormat()` on the passed `FileInterface` instance when unsupported formats are excluded
