### PR TITLE
Fix: Case mismatch between loaded and declared class names

### DIFF
--- a/src/Method/Command/X7zip.php
+++ b/src/Method/Command/X7zip.php
@@ -21,7 +21,7 @@ use Distill\Method\MethodInterface;
  *
  * @author Raul Fraile <raulfraile@gmail.com>
  */
-class X7Zip extends AbstractCommandMethod
+class X7zip extends AbstractCommandMethod
 {
     const EXIT_CODE_OK = 0;
     const EXIT_CODE_WARNING = 1;

--- a/tests/DistillTest.php
+++ b/tests/DistillTest.php
@@ -7,7 +7,7 @@ use Distill\Format;
 use Distill\Exception;
 use Distill\Method\Command\Cabextract;
 use Distill\Method\Command\Gnome\Gcab;
-use Distill\Method\Command\X7Zip;
+use Distill\Method\Command\X7zip;
 
 class DistillTest extends TestCase
 {
@@ -432,7 +432,7 @@ class DistillTest extends TestCase
 
         $this->distill->disableMethod(Cabextract::getName());
         $this->distill->disableMethod(Gcab::getName());
-        $this->distill->disableMethod(X7Zip::getName());
+        $this->distill->disableMethod(X7zip::getName());
 
         $result = $this->distill
             ->extract($this->filesPath.'file_ok.cab', $target, new Format\Simple\Cab());

--- a/tests/Method/Command/X7zipTest.php
+++ b/tests/Method/Command/X7zipTest.php
@@ -10,7 +10,7 @@ class X7zipTest extends AbstractMethodTest
 {
     public function setUp()
     {
-        $this->method = new Method\Command\X7Zip();
+        $this->method = new Method\Command\X7zip();
 
         if (false === $this->method->isSupported()) {
             $this->markTestSkipped('The 7zip command is not installed');


### PR DESCRIPTION
Fix: Case mismatch between loaded and declared class names: Distill\Method\Command\X7zip vs Distill\Method\Command\X7Zip