### PR TITLE
Allow Symfony 3 dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ cache:
 
 language: php
 
+env:
+  - COMPOSER_FLAGS="--prefer-source"
+
 php:
   - 5.4
   - 5.5
@@ -24,12 +27,15 @@ php:
 
 matrix:
   fast_finish: true
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then pecl install rar; fi;'
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then echo "phar.readonly = 0" > travis.hhvm.ini; fi;'
   - composer self-update
-  - composer install --prefer-source
+  - composer update $COMPOSER_FLAGS
 
 script:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpunit --verbose; else hhvm -c travis.hhvm.ini ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": ">=5.4.0",
         "pimple/pimple": "~3.0",
-        "symfony/filesystem": "~2.4",
-        "symfony/process": "~2.4"
+        "symfony/filesystem": "~2.4|^3.0",
+        "symfony/process": "~2.4|^3.0"
     },
     "require-dev": {
         "raulfraile/ladybug": "~1.0",
         "mockery/mockery": "0.9.1",
-        "symfony/finder": "~2.4"
+        "symfony/finder": "~2.4|^3.0"
     },
     "suggest": {
         "ext-zip": "Allows to uncompress zip files using ZipArchive",


### PR DESCRIPTION
This changes should allow projects using Symfony 3 components to use Distill as well.

The changes to `.travis.yml` should let Travis test everything with the Symfony 3 dependencies, but there is one additional target in the matrix that tests the package against the lowest supported PHP version with the lowest requirements, so that everything should be covered.

About the change from `composer install` to `composer update` - in a library without a `composer.lock` file, there should be no difference between the two, except that the `install` command doesn't accept the `--prefer-lowest` option.

Cheers, and thank you for your package!
